### PR TITLE
Initialize Flutter project skeleton with Firebase setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # day-log-flutter
-flutter version of the app
+
+This repository contains a minimal Flutter application pre-configured with Firebase.
+
+## Getting Started
+
+1. Install Flutter and set up your development environment.
+2. Run `flutter pub get` to fetch dependencies.
+3. Configure Firebase for Android, iOS, and Web as described in the [Firebase documentation](https://firebase.google.com/docs/flutter/setup).
+4. Run the app with `flutter run`.
+
+The project already includes folders:
+- `lib/screens/`
+- `lib/widgets/`
+- `lib/models/`
+- `lib/services/`
+- `lib/providers/`
+
+Firebase Auth, Cloud Firestore, and Storage are added as dependencies and initialized in `FirebaseService`.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'services/firebase_service.dart';
+import 'providers/auth_provider.dart';
+import 'screens/home_screen.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await FirebaseService.initialize();
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => AuthProvider(),
+      child: MaterialApp(
+        title: 'Flutter Firebase App',
+        theme: ThemeData(primarySwatch: Colors.blue),
+        home: const HomeScreen(),
+      ),
+    );
+  }
+}

--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -1,0 +1,12 @@
+class UserModel {
+  final String id;
+  final String? name;
+
+  UserModel({required this.id, this.name});
+
+  Map<String, dynamic> toMap() => {'id': id, 'name': name};
+
+  factory UserModel.fromMap(Map<String, dynamic> map) {
+    return UserModel(id: map['id'] as String, name: map['name'] as String?);
+  }
+}

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../services/firebase_service.dart';
+
+class AuthProvider extends ChangeNotifier {
+  Stream<User?> get authStateChanges => FirebaseService.auth.authStateChanges();
+
+  Future<void> signInAnonymously() async {
+    await FirebaseService.auth.signInAnonymously();
+  }
+
+  Future<void> signOut() async {
+    await FirebaseService.auth.signOut();
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Home')),
+      body: const Center(child: Text('Welcome')),
+    );
+  }
+}

--- a/lib/services/firebase_service.dart
+++ b/lib/services/firebase_service.dart
@@ -1,0 +1,14 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+
+class FirebaseService {
+  static FirebaseAuth get auth => FirebaseAuth.instance;
+  static FirebaseFirestore get firestore => FirebaseFirestore.instance;
+  static FirebaseStorage get storage => FirebaseStorage.instance;
+
+  static Future<FirebaseApp> initialize() async {
+    return Firebase.initializeApp();
+  }
+}

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -1,0 +1,14 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/user_model.dart';
+
+class FirestoreService {
+  final _users = FirebaseFirestore.instance.collection('users');
+
+  Future<void> addUser(UserModel user) {
+    return _users.doc(user.id).set(user.toMap());
+  }
+
+  Stream<UserModel> getUser(String id) {
+    return _users.doc(id).snapshots().map((s) => UserModel.fromMap(s.data()!));
+  }
+}

--- a/lib/widgets/custom_button.dart
+++ b/lib/widgets/custom_button.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class CustomButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onPressed;
+
+  const CustomButton({super.key, required this.label, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      child: Text(label),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,24 @@
+name: day_log_flutter
+description: A Flutter app with Firebase.
+publish_to: 'none'
+version: 1.0.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+  firebase_core: ^2.27.0
+  firebase_auth: ^4.17.4
+  cloud_firestore: ^4.15.5
+  firebase_storage: ^11.6.5
+  provider: ^6.1.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add Flutter project structure with lib subfolders
- add Firebase packages to `pubspec.yaml`
- implement `FirebaseService` for auth, firestore and storage
- add `AuthProvider` and basic `HomeScreen`
- update README with setup instructions

## Testing
- `apt-get update` *(fails: 403 Forbidden for mise.jdx.dev)*

------
https://chatgpt.com/codex/tasks/task_e_687dfc2ac4f883298d5df5bae1302ff9