### PR TITLE
Add Firebase auth skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+.pub/
+build/
+.flutter-plugins
+.flutter-plugins-dependencies
+.gradle
+**/*.iml
+.idea/
+
+# Visual Studio Code
+.vscode/
+
+# Misc
+*.log

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# day-log-flutter
-flutter version of the app
+# Day Log Flutter
+
+A simple Flutter project demonstrating Firebase authentication with Google and email/password sign-in. User data is stored in Firestore under `/users/{uid}`.
+
+## Firebase setup
+1. Create a Firebase project and add Android/iOS apps.
+2. Download the platform configuration files and place them in the respective directories (`android/app/google-services.json` and `ios/Runner/GoogleService-Info.plist`).
+3. Enable **Google** and **Email/Password** sign-in methods in the Firebase console.
+4. Run `flutter pub get` to install dependencies.
+5. Launch the app with `flutter run`.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'services/auth_service.dart';
+import 'models/user_model.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Day Log',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const AuthGate(),
+    );
+  }
+}
+
+class AuthGate extends StatefulWidget {
+  const AuthGate({super.key});
+
+  @override
+  State<AuthGate> createState() => _AuthGateState();
+}
+
+class _AuthGateState extends State<AuthGate> {
+  UserModel? _user;
+  final AuthService _auth = AuthService();
+
+  @override
+  void initState() {
+    super.initState();
+    _auth.userStream.listen((u) {
+      setState(() {
+        _user = u;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_user == null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Sign In')),
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                onPressed: _auth.signInWithGoogle,
+                child: const Text('Sign In with Google'),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () async {
+                  await _auth.signInWithEmail('demo@example.com', 'password');
+                },
+                child: const Text('Sign In with Email'),
+              )
+            ],
+          ),
+        ),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Welcome ${_user!.displayName ?? _user!.email}'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            onPressed: _auth.signOut,
+          )
+        ],
+      ),
+      body: const Center(child: Text('Logged In')),
+    );
+  }
+}

--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -1,0 +1,25 @@
+class UserModel {
+  final String uid;
+  final String? email;
+  final String? displayName;
+  final String? photoUrl;
+
+  UserModel({required this.uid, this.email, this.displayName, this.photoUrl});
+
+  factory UserModel.fromMap(String uid, Map<String, dynamic> data) {
+    return UserModel(
+      uid: uid,
+      email: data['email'] as String?,
+      displayName: data['displayName'] as String?,
+      photoUrl: data['photoUrl'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'email': email,
+      'displayName': displayName,
+      'photoUrl': photoUrl,
+    }..removeWhere((key, value) => value == null);
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+import '../models/user_model.dart';
+
+class AuthService {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+
+  Stream<UserModel?> get userStream => _auth.authStateChanges().asyncMap(_userFromFirebase);
+
+  Future<UserModel?> _userFromFirebase(User? user) async {
+    if (user == null) return null;
+    final doc = _db.collection('users').doc(user.uid);
+    final snap = await doc.get();
+    if (!snap.exists) {
+      final newUser = UserModel(
+        uid: user.uid,
+        email: user.email,
+        displayName: user.displayName,
+        photoUrl: user.photoURL,
+      );
+      await doc.set(newUser.toMap());
+      return newUser;
+    }
+    return UserModel.fromMap(user.uid, snap.data()!);
+  }
+
+  Future<UserModel?> signInWithGoogle() async {
+    final GoogleSignInAccount? googleUser = await GoogleSignIn().signIn();
+    if (googleUser == null) return null;
+    final googleAuth = await googleUser.authentication;
+    final credential = GoogleAuthProvider.credential(
+      accessToken: googleAuth.accessToken,
+      idToken: googleAuth.idToken,
+    );
+    final userCred = await _auth.signInWithCredential(credential);
+    return _userFromFirebase(userCred.user);
+  }
+
+  Future<UserModel?> registerWithEmail(String email, String password) async {
+    final cred = await _auth.createUserWithEmailAndPassword(email: email, password: password);
+    return _userFromFirebase(cred.user);
+  }
+
+  Future<UserModel?> signInWithEmail(String email, String password) async {
+    final cred = await _auth.signInWithEmailAndPassword(email: email, password: password);
+    return _userFromFirebase(cred.user);
+  }
+
+  Future<void> signOut() async {
+    await _auth.signOut();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,22 @@
+name: day_log_flutter
+description: A Flutter project with Firebase Auth
+publish_to: 'none'
+version: 1.0.0+1
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  firebase_core: ^2.30.0
+  firebase_auth: ^4.16.0
+  cloud_firestore: ^4.17.0
+  google_sign_in: ^6.2.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.1
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add Flutter pubspec with Firebase dependencies
- implement `UserModel`
- implement `AuthService` for Google and Email/Password login with Firestore user storage
- add minimal demo `main.dart`
- document Firebase setup
- add Flutter `.gitignore`

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*
- `apt-get update` *(fails: blocked domain)*

------
https://chatgpt.com/codex/tasks/task_e_687e004d16d08329bdd013ae5293fc48