### PR TITLE
Add Flutter timeline screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Flutter/Pub related
+.dart_tool/
+.packages
+.build/
+pubspec.lock
+# Misc
+.idea/
+.vscode/
+# Build outputs
+build/

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'timeline_screen.dart';
+
+void main() {
+  runApp(const DayLogApp());
+}
+
+class DayLogApp extends StatelessWidget {
+  const DayLogApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Day Log',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: const TimelineScreen(),
+    );
+  }
+}

--- a/lib/timeline_screen.dart
+++ b/lib/timeline_screen.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+
+class TimelineEntry {
+  final String text;
+  final DateTime timestamp;
+  final String? imageUrl;
+
+  TimelineEntry({required this.text, required this.timestamp, this.imageUrl});
+}
+
+class TimelineScreen extends StatefulWidget {
+  const TimelineScreen({super.key});
+
+  @override
+  State<TimelineScreen> createState() => _TimelineScreenState();
+}
+
+class _TimelineScreenState extends State<TimelineScreen> with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  final List<TimelineEntry> _followingEntries = [
+    TimelineEntry(text: 'Followed user post 1', timestamp: DateTime.now().subtract(const Duration(minutes: 5))),
+    TimelineEntry(text: 'Followed user post 2 with image', timestamp: DateTime.now().subtract(const Duration(hours: 1)), imageUrl: null),
+  ];
+
+  final List<TimelineEntry> _exploreEntries = [
+    TimelineEntry(text: 'Explore post 1', timestamp: DateTime.now().subtract(const Duration(days: 1))),
+    TimelineEntry(text: 'Explore post 2 with image', timestamp: DateTime.now().subtract(const Duration(days: 2)), imageUrl: null),
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Timeline'),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Following'),
+            Tab(text: 'Explore'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          _buildList(_followingEntries),
+          _buildList(_exploreEntries),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildList(List<TimelineEntry> entries) {
+    return ListView.builder(
+      padding: const EdgeInsets.all(8),
+      itemCount: entries.length,
+      itemBuilder: (context, index) {
+        final entry = entries[index];
+        return Card(
+          margin: const EdgeInsets.symmetric(vertical: 8),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(entry.text, style: const TextStyle(fontSize: 16)),
+                if (entry.imageUrl != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 8),
+                    child: Image.network(entry.imageUrl!),
+                  ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    _formatTimestamp(entry.timestamp),
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  String _formatTimestamp(DateTime time) {
+    return '${time.year}-${time.month.toString().padLeft(2, '0')}-${time.day.toString().padLeft(2, '0')} '
+        '${time.hour.toString().padLeft(2, '0')}:${time.minute.toString().padLeft(2, '0')}';
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,19 @@
+name: day_log_flutter
+description: Flutter version of Day Log app
+version: 0.1.0
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- initialize minimal Flutter project
- implement `TimelineScreen` with toggle between "Following" and "Explore" tabs
- include mock timeline entries displayed as cards

## Testing
- `flutter --version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_687e0112b51483298845cdf9cdd081cc