### PR TITLE
Add diary entry model and creation screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # day-log-flutter
-flutter version of the app
+
+This repository contains a minimal Flutter implementation of a diary app. The main feature implemented is a screen to create new diary entries and save them to a Firestore collection called **`entries`**.
+
+## Firestore
+
+Diary entries are stored in the collection `/entries`. Each document has the following fields:
+
+- `text` – body of the entry
+- `tag` – optional tag for categorizing entries
+- `visibility` – either `public` or `private`
+- `mediaUrl` – optional URL of an uploaded photo
+- `createdAt` – server timestamp
+
+## Running the app
+
+Configure Firebase for your Flutter project and ensure `firebase_core`, `cloud_firestore`, `firebase_storage` and `image_picker` dependencies are installed. Launch the app as a normal Flutter application. The home screen lets you create a new entry with text, tag, visibility and an optional image. Once saved, the entry document appears in the `/entries` collection.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'screens/new_entry_screen.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Day Log',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const NewEntryScreen(),
+    );
+  }
+}

--- a/lib/models/diary_entry.dart
+++ b/lib/models/diary_entry.dart
@@ -1,0 +1,37 @@
+enum EntryVisibility { public, private }
+
+class DiaryEntry {
+  final String id;
+  final String text;
+  final String tag;
+  final EntryVisibility visibility;
+  final String? mediaUrl;
+
+  DiaryEntry({
+    required this.id,
+    required this.text,
+    required this.tag,
+    required this.visibility,
+    this.mediaUrl,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'text': text,
+      'tag': tag,
+      'visibility': visibility.name,
+      'mediaUrl': mediaUrl,
+    };
+  }
+
+  factory DiaryEntry.fromMap(String id, Map<String, dynamic> map) {
+    return DiaryEntry(
+      id: id,
+      text: map['text'] as String? ?? '',
+      tag: map['tag'] as String? ?? '',
+      visibility: EntryVisibility.values
+          .firstWhere((v) => v.name == map['visibility'], orElse: () => EntryVisibility.private),
+      mediaUrl: map['mediaUrl'] as String?,
+    );
+  }
+}

--- a/lib/screens/new_entry_screen.dart
+++ b/lib/screens/new_entry_screen.dart
@@ -1,0 +1,131 @@
+import 'dart:io';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../models/diary_entry.dart';
+
+class NewEntryScreen extends StatefulWidget {
+  const NewEntryScreen({super.key});
+
+  @override
+  State<NewEntryScreen> createState() => _NewEntryScreenState();
+}
+
+class _NewEntryScreenState extends State<NewEntryScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _textController = TextEditingController();
+  final _tagController = TextEditingController();
+  EntryVisibility _visibility = EntryVisibility.private;
+  File? _mediaFile;
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    _tagController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickMedia() async {
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(source: ImageSource.gallery);
+    if (picked != null) {
+      setState(() {
+        _mediaFile = File(picked.path);
+      });
+    }
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    await Firebase.initializeApp();
+    String? mediaUrl;
+    if (_mediaFile != null) {
+      final storageRef = FirebaseStorage.instance
+          .ref()
+          .child('entry_media')
+          .child(DateTime.now().millisecondsSinceEpoch.toString());
+      await storageRef.putFile(_mediaFile!);
+      mediaUrl = await storageRef.getDownloadURL();
+    }
+
+    final doc = await FirebaseFirestore.instance.collection('entries').add({
+      'text': _textController.text,
+      'tag': _tagController.text,
+      'visibility': _visibility.name,
+      'mediaUrl': mediaUrl,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text('Entry ${doc.id} saved')));
+    _formKey.currentState!.reset();
+    setState(() {
+      _mediaFile = null;
+      _visibility = EntryVisibility.private;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('New Entry')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextFormField(
+                controller: _textController,
+                decoration: const InputDecoration(labelText: 'Text'),
+                validator: (v) => v == null || v.isEmpty ? 'Enter text' : null,
+                maxLines: 4,
+              ),
+              TextFormField(
+                controller: _tagController,
+                decoration: const InputDecoration(labelText: 'Tag'),
+              ),
+              const SizedBox(height: 12),
+              DropdownButtonFormField<EntryVisibility>(
+                value: _visibility,
+                decoration: const InputDecoration(labelText: 'Visibility'),
+                items: EntryVisibility.values
+                    .map((e) => DropdownMenuItem(
+                          value: e,
+                          child: Text(e.name),
+                        ))
+                    .toList(),
+                onChanged: (v) {
+                  if (v != null) {
+                    setState(() {
+                      _visibility = v;
+                    });
+                  }
+                },
+              ),
+              const SizedBox(height: 12),
+              if (_mediaFile != null)
+                Image.file(_mediaFile!, height: 150),
+              TextButton.icon(
+                onPressed: _pickMedia,
+                icon: const Icon(Icons.photo),
+                label: Text(_mediaFile == null ? 'Add Media' : 'Change Media'),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _submit,
+                child: const Text('Save Entry'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,16 @@
+name: day_log_flutter
+description: Simple diary app.
+version: 0.1.0
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  firebase_core: ^2.10.0
+  cloud_firestore: ^4.9.0
+  firebase_storage: ^11.2.0
+  image_picker: ^1.0.7
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- initialize a minimal Flutter project structure
- add DiaryEntry model for Firestore
- implement `NewEntryScreen` to create entries
- document Firestore `/entries` usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e04ae6ef083299e0b0dc07c17e43e