### PR TITLE
Add Firebase Auth social login and onboarding flow

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,20 +1,30 @@
 import 'package:flutter/material.dart';
-import 'config/environment.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class MyApp extends StatelessWidget {
+import 'config/environment.dart';
+import 'screens/auth/login_screen.dart';
+import 'screens/home_screen.dart';
+import 'state/auth_providers.dart';
+
+class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final env = EnvironmentConfig.environment;
+    final auth = ref.watch(authStateProvider);
     return MaterialApp(
-      title: 'Daylog',
-      home: Scaffold(
-        appBar: AppBar(title: const Text('Daylog')),
-        body: Center(
-          child: Text('Running in ' + env.name + ' mode'),
+      title: 'Daylog - ${env.name}',
+      home: auth.when(
+        data: (user) => user == null ? const LoginScreen() : const HomeScreen(),
+        loading: () => const Scaffold(
+          body: Center(child: CircularProgressIndicator()),
+        ),
+        error: (e, _) => Scaffold(
+          body: Center(child: Text('Error: $e')),
         ),
       ),
+      debugShowCheckedModeBanner: false,
     );
   }
 }

--- a/lib/main_common.dart
+++ b/lib/main_common.dart
@@ -1,8 +1,13 @@
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import 'app.dart';
 import 'config/environment.dart';
 
-void mainCommon(AppEnvironment env) {
+Future<void> mainCommon(AppEnvironment env) async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
   EnvironmentConfig.initialize(env);
-  runApp(const MyApp());
+  runApp(const ProviderScope(child: MyApp()));
 }

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -1,0 +1,42 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class UserProfile {
+  final String uid;
+  final String email;
+  final String? username;
+  final String? photoUrl;
+  final List<String> moods;
+  final List<String> interests;
+
+  UserProfile({
+    required this.uid,
+    required this.email,
+    this.username,
+    this.photoUrl,
+    this.moods = const [],
+    this.interests = const [],
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'uid': uid,
+      'email': email,
+      'username': username,
+      'photoUrl': photoUrl,
+      'moods': moods,
+      'interests': interests,
+    };
+  }
+
+  factory UserProfile.fromDoc(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>?;
+    return UserProfile(
+      uid: doc.id,
+      email: data?['email'] ?? '',
+      username: data?['username'],
+      photoUrl: data?['photoUrl'],
+      moods: List<String>.from(data?['moods'] ?? []),
+      interests: List<String>.from(data?['interests'] ?? []),
+    );
+  }
+}

--- a/lib/screens/auth/login_screen.dart
+++ b/lib/screens/auth/login_screen.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../state/auth_providers.dart';
+import 'signup_screen.dart';
+import 'password_reset_screen.dart';
+
+class LoginScreen extends ConsumerStatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  ConsumerState<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends ConsumerState<LoginScreen> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final authState = ref.watch(authControllerProvider);
+    ref.listen(authControllerProvider, (previous, next) {
+      if (next.hasError) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(next.error.toString())),
+        );
+      }
+    });
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: authState.isLoading
+                  ? null
+                  : () => ref
+                      .read(authControllerProvider.notifier)
+                      .signInWithEmail(
+                        _emailController.text,
+                        _passwordController.text,
+                      ),
+              child: authState.isLoading
+                  ? const CircularProgressIndicator()
+                  : const Text('Login'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const SignupScreen()),
+              ),
+              child: const Text('Create account'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const PasswordResetScreen()),
+              ),
+              child: const Text('Forgot password?'),
+            ),
+            const Divider(),
+            ElevatedButton(
+              onPressed: () => ref
+                  .read(authControllerProvider.notifier)
+                  .signInWithGoogle(),
+              child: const Text('Sign in with Google'),
+            ),
+            ElevatedButton(
+              onPressed: () => ref
+                  .read(authControllerProvider.notifier)
+                  .signInWithApple(),
+              child: const Text('Sign in with Apple'),
+            ),
+            ElevatedButton(
+              onPressed: () => ref
+                  .read(authControllerProvider.notifier)
+                  .signInWithFacebook(),
+              child: const Text('Sign in with Facebook'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/auth/password_reset_screen.dart
+++ b/lib/screens/auth/password_reset_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../state/auth_providers.dart';
+
+class PasswordResetScreen extends ConsumerStatefulWidget {
+  const PasswordResetScreen({super.key});
+
+  @override
+  ConsumerState<PasswordResetScreen> createState() => _PasswordResetScreenState();
+}
+
+class _PasswordResetScreenState extends ConsumerState<PasswordResetScreen> {
+  final _emailController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final authService = ref.watch(authServiceProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Reset Password')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () async {
+                await authService.resetPassword(_emailController.text);
+                if (mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Password reset email sent')),
+                  );
+                }
+              },
+              child: const Text('Send reset link'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/auth/signup_screen.dart
+++ b/lib/screens/auth/signup_screen.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../state/auth_providers.dart';
+import '../onboarding/onboarding_screen.dart';
+
+class SignupScreen extends ConsumerStatefulWidget {
+  const SignupScreen({super.key});
+
+  @override
+  ConsumerState<SignupScreen> createState() => _SignupScreenState();
+}
+
+class _SignupScreenState extends ConsumerState<SignupScreen> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final authState = ref.watch(authControllerProvider);
+    ref.listen(authControllerProvider, (previous, next) {
+      if (next.hasError) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(next.error.toString())),
+        );
+      }
+    });
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sign Up')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: authState.isLoading
+                  ? null
+                  : () async {
+                      await ref
+                          .read(authControllerProvider.notifier)
+                          .signUpWithEmail(
+                            _emailController.text,
+                            _passwordController.text,
+                          );
+                      if (mounted && !authState.hasError) {
+                        Navigator.pushReplacement(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => const OnboardingScreen(),
+                          ),
+                        );
+                      }
+                    },
+              child: authState.isLoading
+                  ? const CircularProgressIndicator()
+                  : const Text('Sign Up'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,43 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../state/auth_providers.dart';
+
+class HomeScreen extends ConsumerWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final user = FirebaseAuth.instance.currentUser;
+    final profile = ref.watch(userProfileProvider).asData?.value;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Welcome ${profile?.username ?? user?.email ?? ''}'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            onPressed: () => ref.read(authControllerProvider.notifier).signOut(),
+          ),
+        ],
+      ),
+      body: Center(
+        child: profile == null
+            ? const CircularProgressIndicator()
+            : Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (profile.photoUrl != null)
+                    CircleAvatar(
+                      backgroundImage: NetworkImage(profile.photoUrl!),
+                      radius: 40,
+                    ),
+                  const SizedBox(height: 16),
+                  Text('Moods: ${profile.moods.join(', ')}'),
+                  Text('Interests: ${profile.interests.join(', ')}'),
+                ],
+              ),
+      ),
+    );
+  }
+}

--- a/lib/screens/onboarding/onboarding_screen.dart
+++ b/lib/screens/onboarding/onboarding_screen.dart
@@ -1,0 +1,144 @@
+import 'dart:io';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../../models/user_profile.dart';
+import '../../state/auth_providers.dart';
+
+class OnboardingScreen extends ConsumerStatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  ConsumerState<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
+  final _usernameController = TextEditingController();
+  File? _image;
+  final List<String> _selectedMoods = [];
+  final List<String> _selectedInterests = [];
+
+  final _moods = const ['Happy', 'Sad', 'Excited', 'Calm'];
+  final _interests = const ['Music', 'Sports', 'Art', 'Travel'];
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickImage() async {
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(source: ImageSource.gallery);
+    if (picked != null) {
+      setState(() {
+        _image = File(picked.path);
+      });
+    }
+  }
+
+  Future<String?> _uploadImage(String uid) async {
+    if (_image == null) return null;
+    final ref = FirebaseStorage.instance.ref('profilePictures/$uid.jpg');
+    await ref.putFile(_image!);
+    return await ref.getDownloadURL();
+  }
+
+  Future<void> _complete() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+    final photoUrl = await _uploadImage(user.uid);
+    final profile = UserProfile(
+      uid: user.uid,
+      email: user.email ?? '',
+      username: _usernameController.text,
+      photoUrl: photoUrl,
+      moods: _selectedMoods,
+      interests: _selectedInterests,
+    );
+    await ref.read(authServiceProvider).createUserProfile(profile);
+    if (mounted) {
+      Navigator.of(context).popUntil((route) => route.isFirst);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Set up your profile')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _usernameController,
+              decoration: const InputDecoration(labelText: 'Username'),
+            ),
+            const SizedBox(height: 16),
+            GestureDetector(
+              onTap: _pickImage,
+              child: CircleAvatar(
+                radius: 40,
+                backgroundImage: _image != null ? FileImage(_image!) : null,
+                child: _image == null
+                    ? const Icon(Icons.camera_alt, size: 32)
+                    : null,
+              ),
+            ),
+            const SizedBox(height: 16),
+            const Text('Select moods'),
+            Wrap(
+              spacing: 8,
+              children: _moods.map((m) {
+                final selected = _selectedMoods.contains(m);
+                return FilterChip(
+                  label: Text(m),
+                  selected: selected,
+                  onSelected: (val) {
+                    setState(() {
+                      if (val) {
+                        _selectedMoods.add(m);
+                      } else {
+                        _selectedMoods.remove(m);
+                      }
+                    });
+                  },
+                );
+              }).toList(),
+            ),
+            const SizedBox(height: 16),
+            const Text('Select interests'),
+            Wrap(
+              spacing: 8,
+              children: _interests.map((i) {
+                final selected = _selectedInterests.contains(i);
+                return FilterChip(
+                  label: Text(i),
+                  selected: selected,
+                  onSelected: (val) {
+                    setState(() {
+                      if (val) {
+                        _selectedInterests.add(i);
+                      } else {
+                        _selectedInterests.remove(i);
+                      }
+                    });
+                  },
+                );
+              }).toList(),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: _complete,
+              child: const Text('Finish'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,84 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+
+import '../models/user_profile.dart';
+
+class AuthService {
+  final FirebaseAuth _auth;
+  final FirebaseFirestore _firestore;
+
+  AuthService(this._auth, this._firestore);
+
+  Stream<User?> authStateChanges() => _auth.authStateChanges();
+
+  Future<UserCredential> signUpWithEmail(String email, String password) async {
+    return await _auth.createUserWithEmailAndPassword(
+      email: email,
+      password: password,
+    );
+  }
+
+  Future<UserCredential> signInWithEmail(String email, String password) async {
+    return await _auth.signInWithEmailAndPassword(
+      email: email,
+      password: password,
+    );
+  }
+
+  Future<void> resetPassword(String email) async {
+    await _auth.sendPasswordResetEmail(email: email);
+  }
+
+  Future<UserCredential> signInWithGoogle() async {
+    final GoogleSignInAccount? googleUser = await GoogleSignIn().signIn();
+    if (googleUser == null) {
+      throw FirebaseAuthException(
+        code: 'ERROR_ABORTED_BY_USER',
+        message: 'Sign in aborted by user',
+      );
+    }
+    final googleAuth = await googleUser.authentication;
+    final credential = GoogleAuthProvider.credential(
+      accessToken: googleAuth.accessToken,
+      idToken: googleAuth.idToken,
+    );
+    return await _auth.signInWithCredential(credential);
+  }
+
+  Future<UserCredential> signInWithApple() async {
+    final result = await SignInWithApple.getAppleIDCredential(
+      scopes: [AppleIDAuthorizationScopes.email, AppleIDAuthorizationScopes.fullName],
+    );
+    final oauthCredential = OAuthProvider('apple.com').credential(
+      idToken: result.identityToken,
+      accessToken: result.authorizationCode,
+    );
+    return await _auth.signInWithCredential(oauthCredential);
+  }
+
+  Future<UserCredential> signInWithFacebook() async {
+    final LoginResult result = await FacebookAuth.instance.login();
+    if (result.status != LoginStatus.success) {
+      throw FirebaseAuthException(
+        code: 'ERROR_ABORTED_BY_USER',
+        message: result.message,
+      );
+    }
+    final OAuthCredential credential =
+        FacebookAuthProvider.credential(result.accessToken!.token);
+    return await _auth.signInWithCredential(credential);
+  }
+
+  Future<void> signOut() async {
+    await _auth.signOut();
+    await GoogleSignIn().signOut();
+    await FacebookAuth.instance.logOut();
+  }
+
+  Future<void> createUserProfile(UserProfile profile) async {
+    await _firestore.collection('users').doc(profile.uid).set(profile.toMap());
+  }
+}

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -1,0 +1,14 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../models/user_profile.dart';
+
+class UserService {
+  final FirebaseFirestore _firestore;
+  UserService(this._firestore);
+
+  Future<UserProfile?> getUserProfile(String uid) async {
+    final doc = await _firestore.collection('users').doc(uid).get();
+    if (!doc.exists) return null;
+    return UserProfile.fromDoc(doc);
+  }
+}

--- a/lib/state/auth_providers.dart
+++ b/lib/state/auth_providers.dart
@@ -1,0 +1,97 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/user_profile.dart';
+import '../services/auth_service.dart';
+import '../services/user_service.dart';
+
+final firebaseAuthProvider = Provider<FirebaseAuth>((ref) {
+  return FirebaseAuth.instance;
+});
+
+final firestoreProvider = Provider<FirebaseFirestore>((ref) {
+  return FirebaseFirestore.instance;
+});
+
+final authServiceProvider = Provider<AuthService>((ref) {
+  return AuthService(ref.watch(firebaseAuthProvider), ref.watch(firestoreProvider));
+});
+
+final userServiceProvider = Provider<UserService>((ref) {
+  return UserService(ref.watch(firestoreProvider));
+});
+
+final authStateProvider = StreamProvider<User?>((ref) {
+  return ref.watch(authServiceProvider).authStateChanges();
+});
+
+class AuthController extends StateNotifier<AsyncValue<User?>> {
+  final AuthService _service;
+  AuthController(this._service) : super(const AsyncValue.loading()) {
+    _service.authStateChanges().listen((user) {
+      state = AsyncValue.data(user);
+    });
+  }
+
+  Future<void> signInWithEmail(String email, String password) async {
+    state = const AsyncValue.loading();
+    try {
+      await _service.signInWithEmail(email, password);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<void> signUpWithEmail(String email, String password) async {
+    state = const AsyncValue.loading();
+    try {
+      await _service.signUpWithEmail(email, password);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<void> signInWithGoogle() async {
+    state = const AsyncValue.loading();
+    try {
+      await _service.signInWithGoogle();
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<void> signInWithApple() async {
+    state = const AsyncValue.loading();
+    try {
+      await _service.signInWithApple();
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<void> signInWithFacebook() async {
+    state = const AsyncValue.loading();
+    try {
+      await _service.signInWithFacebook();
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  Future<void> signOut() async {
+    state = const AsyncValue.loading();
+    await _service.signOut();
+  }
+}
+
+final authControllerProvider =
+    StateNotifierProvider<AuthController, AsyncValue<User?>>((ref) {
+  return AuthController(ref.watch(authServiceProvider));
+});
+
+final userProfileProvider = FutureProvider<UserProfile?>((ref) async {
+  final user = ref.watch(authStateProvider).asData?.value;
+  if (user == null) return null;
+  return await ref.watch(userServiceProvider).getUserProfile(user.uid);
+});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
   firebase_storage: ^11.5.4
   firebase_messaging: ^14.7.10
   flutter_riverpod: ^2.4.9
+  google_sign_in: ^5.4.2
+  sign_in_with_apple: ^5.0.0
+  flutter_facebook_auth: ^6.0.4
   file_picker: ^5.5.0
   image_picker: ^1.0.4
   video_player: ^2.7.2


### PR DESCRIPTION
## Summary
- add Firebase authentication service supporting email, Google, Apple and Facebook sign-in
- wire up Riverpod providers and auth flow with onboarding for username, avatar, moods and interests
- create login, signup, password reset and home screens

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `dart format lib` *(fails: command not found)*
- `sudo apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `sudo apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_688f223703f08329a44edb1f34ffb4e4